### PR TITLE
feat(auth): add sign-in and sign-up forms

### DIFF
--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,11 @@
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <div className="w-full max-w-md">{children}</div>
+    </div>
+  );
+}

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,0 +1,5 @@
+import { SignInForm } from "@/modules/auth/components/sign-in-form";
+
+export default function SignInPage() {
+  return <SignInForm />;
+}

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -1,0 +1,5 @@
+import { SignUpForm } from "@/modules/auth/components/sign-up-form";
+
+export default function SignUpPage() {
+  return <SignUpForm />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/modules/layout/components/providers";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,7 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Providers>{children}</Providers>
+        <Providers>
+          {children}
+          <Toaster />
+        </Providers>
       </body>
     </html>
   );

--- a/src/modules/auth/components/password-input.tsx
+++ b/src/modules/auth/components/password-input.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { Eye, EyeOff } from "lucide-react";
+import type { ComponentProps } from "react";
+import { forwardRef, useState } from "react";
+
+type PasswordInputProps = ComponentProps<typeof Input> & {
+  /**
+   * Whether to show the password toggle button
+   * @default true
+   */
+  showToggle?: boolean;
+};
+
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, showToggle = true, ...props }, ref) => {
+    const [showPassword, setShowPassword] = useState(false);
+
+    return (
+      <div className="relative">
+        <Input
+          type={showPassword ? "text" : "password"}
+          className={cn(showToggle && "pr-10", className)}
+          ref={ref}
+          {...props}
+        />
+        {showToggle && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+            tabIndex={-1}
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </Button>
+        )}
+      </div>
+    );
+  }
+);
+
+PasswordInput.displayName = "PasswordInput";

--- a/src/modules/auth/components/sign-in-form.tsx
+++ b/src/modules/auth/components/sign-in-form.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { authClient } from "@/modules/auth/lib/auth-client";
+import { signInSchema } from "@/modules/auth/schemas";
+import type { SignInFormData } from "@/modules/auth/types";
+import { toast } from "sonner";
+import { PasswordInput } from "./password-input";
+
+interface SignInFormProps {
+  onSuccess?: () => void;
+  callbackURL?: string;
+}
+
+export function SignInForm({
+  onSuccess,
+  callbackURL = "/dashboard",
+}: SignInFormProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<SignInFormData>({
+    resolver: zodResolver(signInSchema),
+    mode: "onBlur",
+  });
+
+  const onSubmit = async (data: SignInFormData) => {
+    setFormError(null);
+    setIsLoading(true);
+
+    try {
+      await authClient.signIn.email(
+        {
+          email: data.email,
+          password: data.password,
+          callbackURL,
+        },
+        {
+          onSuccess: () => {
+            setIsLoading(false);
+            toast.success("Sign in successful! Welcome back!");
+            reset();
+            router.push(callbackURL);
+            onSuccess?.();
+          },
+          onError: (ctx) => {
+            setIsLoading(false);
+            setFormError(
+              ctx.error.message || "An error occurred during sign in"
+            );
+          },
+        }
+      );
+    } catch {
+      setIsLoading(false);
+      setFormError("An unexpected error occurred. Please try again.");
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto space-y-4">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">Sign In</h1>
+        <p className="text-muted-foreground">
+          Enter your credentials to access your account
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 mb-0">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="Enter your email"
+            {...register("email")}
+            aria-invalid={!!errors.email}
+            className={errors.email ? "border-destructive" : ""}
+          />
+          {errors.email && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.email.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <PasswordInput
+            id="password"
+            placeholder="Enter your password"
+            {...register("password")}
+            aria-invalid={!!errors.password}
+            className={errors.password ? "border-destructive" : ""}
+          />
+          {errors.password && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.password.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {formError && (
+            <p className="text-sm text-destructive" role="alert">
+              {formError}
+            </p>
+          )}
+        </div>
+
+        <Button
+          type="submit"
+          className="w-full cursor-pointer"
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <>
+              <Spinner className="size-4" />
+              Signing in...
+            </>
+          ) : (
+            "Sign In"
+          )}
+        </Button>
+      </form>
+
+      <div className="text-center mt-2 space-y-2">
+        <Link href="/auth/forgot-password" className="cursor-pointer">
+          <Button variant="link" className="p-0 h-auto text-sm cursor-pointer">
+            Forgot your password?
+          </Button>
+        </Link>
+        <p className="text-sm text-muted-foreground">
+          Don&apos;t have an account?{" "}
+          <Link href="/auth/sign-up" className="cursor-pointer">
+            <Button
+              variant="link"
+              className="p-0 h-auto text-sm cursor-pointer"
+            >
+              Sign up
+            </Button>
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/auth/components/sign-up-form.tsx
+++ b/src/modules/auth/components/sign-up-form.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { authClient } from "@/modules/auth/lib/auth-client";
+import { signUpSchema } from "@/modules/auth/schemas";
+import type { SignUpFormData } from "@/modules/auth/types";
+import { toast } from "sonner";
+import { PasswordInput } from "./password-input";
+
+interface SignUpFormProps {
+  onSuccess?: () => void;
+  callbackURL?: string;
+}
+
+export function SignUpForm({
+  onSuccess,
+  callbackURL = "/dashboard",
+}: SignUpFormProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+    watch,
+  } = useForm<SignUpFormData>({
+    resolver: zodResolver(signUpSchema),
+    mode: "onBlur",
+  });
+
+  const password = watch("password");
+
+  const onSubmit = async (data: SignUpFormData) => {
+    setFormError(null);
+    setIsLoading(true);
+
+    try {
+      await authClient.signUp.email(
+        {
+          email: data.email,
+          password: data.password,
+          name: data.name,
+          callbackURL,
+        },
+        {
+          onSuccess: () => {
+            setIsLoading(false);
+            toast.success(
+              "Account created successfully! Please check your email to verify your account."
+            );
+            reset();
+            router.push("/auth/email-verification");
+            onSuccess?.();
+          },
+          onError: (ctx) => {
+            setIsLoading(false);
+            setFormError(
+              ctx.error.message || "An error occurred during sign up"
+            );
+          },
+        }
+      );
+    } catch {
+      setIsLoading(false);
+      setFormError("An unexpected error occurred. Please try again.");
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto space-y-4">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">Create Account</h1>
+        <p className="text-muted-foreground">
+          Enter your information to create a new account
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 mb-0">
+        <div className="space-y-2">
+          <Label htmlFor="name">Full Name</Label>
+          <Input
+            id="name"
+            type="text"
+            placeholder="Enter your full name"
+            {...register("name")}
+            aria-invalid={!!errors.name}
+            className={errors.name ? "border-destructive" : ""}
+          />
+          {errors.name && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.name.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="Enter your email"
+            {...register("email")}
+            aria-invalid={!!errors.email}
+            className={errors.email ? "border-destructive" : ""}
+          />
+          {errors.email && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.email.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <PasswordInput
+            id="password"
+            placeholder="Create a password"
+            {...register("password")}
+            aria-invalid={!!errors.password}
+            className={errors.password ? "border-destructive" : ""}
+          />
+          {errors.password && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.password.message}
+            </p>
+          )}
+          {password && password.length > 0 && (
+            <div className="space-y-1">
+              <div className="text-xs text-muted-foreground">
+                Password requirements:
+              </div>
+              <div className="grid grid-cols-2 gap-1 text-xs">
+                <div
+                  className={`flex items-center gap-1 ${password.length >= 8 ? "text-green-600" : "text-muted-foreground"}`}
+                >
+                  <div
+                    className={`w-2 h-2 rounded-full ${password.length >= 8 ? "bg-green-600" : "bg-muted"}`}
+                  />
+                  8+ characters
+                </div>
+                <div
+                  className={`flex items-center gap-1 ${/[A-Z]/.test(password) ? "text-green-600" : "text-muted-foreground"}`}
+                >
+                  <div
+                    className={`w-2 h-2 rounded-full ${/[A-Z]/.test(password) ? "bg-green-600" : "bg-muted"}`}
+                  />
+                  Uppercase
+                </div>
+                <div
+                  className={`flex items-center gap-1 ${/[a-z]/.test(password) ? "text-green-600" : "text-muted-foreground"}`}
+                >
+                  <div
+                    className={`w-2 h-2 rounded-full ${/[a-z]/.test(password) ? "bg-green-600" : "bg-muted"}`}
+                  />
+                  Lowercase
+                </div>
+                <div
+                  className={`flex items-center gap-1 ${/\d/.test(password) ? "text-green-600" : "text-muted-foreground"}`}
+                >
+                  <div
+                    className={`w-2 h-2 rounded-full ${/\d/.test(password) ? "bg-green-600" : "bg-muted"}`}
+                  />
+                  Number
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="confirmPassword">Confirm Password</Label>
+          <PasswordInput
+            id="confirmPassword"
+            placeholder="Confirm your password"
+            {...register("confirmPassword")}
+            aria-invalid={!!errors.confirmPassword}
+            className={errors.confirmPassword ? "border-destructive" : ""}
+          />
+          {errors.confirmPassword && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.confirmPassword.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {formError && (
+            <p className="text-sm text-destructive" role="alert">
+              {formError}
+            </p>
+          )}
+        </div>
+
+        <Button
+          type="submit"
+          className="w-full cursor-pointer"
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <>
+              <Spinner className="size-4" />
+              Creating account...
+            </>
+          ) : (
+            "Create Account"
+          )}
+        </Button>
+      </form>
+
+      <div className="text-center mt-2 space-y-2">
+        <p className="text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link href="/auth/sign-in" className="cursor-pointer">
+            <Button
+              variant="link"
+              className="p-0 h-auto text-sm cursor-pointer"
+            >
+              Sign in
+            </Button>
+          </Link>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          By creating an account, you agree to our{" "}
+          <Link
+            href="/legal/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cursor-pointer"
+          >
+            <Button
+              variant="link"
+              className="p-0 h-auto text-xs underline cursor-pointer"
+            >
+              Terms of Service
+            </Button>
+          </Link>{" "}
+          and{" "}
+          <Link
+            href="/legal/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cursor-pointer"
+          >
+            <Button
+              variant="link"
+              className="p-0 h-auto text-xs underline cursor-pointer"
+            >
+              Privacy Policy
+            </Button>
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/auth/schemas/index.ts
+++ b/src/modules/auth/schemas/index.ts
@@ -1,0 +1,2 @@
+export { signInSchema } from "./sign-in";
+export { signUpSchema } from "./sign-up";

--- a/src/modules/auth/schemas/sign-in.ts
+++ b/src/modules/auth/schemas/sign-in.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const signInSchema = z.object({
+  email: z.email("Please enter a valid email address"),
+  password: z
+    .string()
+    .min(1, "Password is required")
+    .min(8, "Password must be at least 8 characters long"),
+});

--- a/src/modules/auth/schemas/sign-up.ts
+++ b/src/modules/auth/schemas/sign-up.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const signUpSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, "Name is required")
+      .min(2, "Name must be at least 2 characters long")
+      .max(50, "Name must be less than 50 characters")
+      .regex(/^[a-zA-Z\s]+$/, "Name can only contain letters and spaces"),
+    email: z.email("Please enter a valid email address"),
+    password: z
+      .string()
+      .min(1, "Password is required")
+      .min(8, "Password must be at least 8 characters long")
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
+        "Password must contain at least one uppercase letter, one lowercase letter, and one number"
+      ),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });

--- a/src/modules/auth/types/index.ts
+++ b/src/modules/auth/types/index.ts
@@ -1,0 +1,2 @@
+export type { SignInFormData, SignInFormProps } from "./sign-in";
+export type { SignUpFormData, SignUpFormProps } from "./sign-up";

--- a/src/modules/auth/types/sign-in.ts
+++ b/src/modules/auth/types/sign-in.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { signInSchema } from "../schemas";
+
+export interface SignInFormProps {
+  onSuccess?: () => void;
+  callbackURL?: string;
+}
+
+export type SignInFormData = z.infer<typeof signInSchema>;

--- a/src/modules/auth/types/sign-up.ts
+++ b/src/modules/auth/types/sign-up.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { signUpSchema } from "../schemas";
+
+export interface SignUpFormProps {
+  onSuccess?: () => void;
+  callbackURL?: string;
+}
+
+export type SignUpFormData = z.infer<typeof signUpSchema>;


### PR DESCRIPTION
This commit introduces the sign-in and sign-up functionality with dedicated forms and UI components.

- Adds `SignInForm` and `SignUpForm` components with validation using `react-hook-form` and `zod`.
- Creates a reusable `PasswordInput` component with a show/hide toggle.
- Creates new pages and a layout for the authentication flow.
- Includes password strength indicators in the sign-up form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced dedicated Sign In and Sign Up pages with client-side validation and clear error messages.
  - Added a reusable password input with visibility toggle and inline password guidance.
  - Implemented toast notifications to provide real-time feedback during authentication flows.
  - Provided a consistent, responsive layout for authentication pages with centered content and improved readability.
  - Included convenient links for account recovery, navigation between auth pages, and legal information.
  - Streamlined post-auth navigation with configurable callback URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->