### PR TITLE
feat(auth): implement email verification and password reset

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@react-email/components": "^0.5.6",
         "@react-email/render": "^1.3.1",
         "@t3-oss/env-nextjs": "^0.13.8",
         "better-auth": "^1.3.25",
@@ -460,7 +461,47 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@react-email/body": ["@react-email/body@0.1.0", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-o1bcSAmDYNNHECbkeyceCVPGmVsYvT+O3sSO/Ct7apKUu3JphTi31hu+0Nwqr/pgV5QFqdoT5vdS3SW5DJFHgQ=="],
+
+    "@react-email/button": ["@react-email/button@0.2.0", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-8i+v6cMxr2emz4ihCrRiYJPp2/sdYsNNsBzXStlcA+/B9Umpm5Jj3WJKYpgTPM+aeyiqlG/MMI1AucnBm4f1oQ=="],
+
+    "@react-email/code-block": ["@react-email/code-block@0.1.0", "", { "dependencies": { "prismjs": "^1.30.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jSpHFsgqnQXxDIssE4gvmdtFncaFQz5D6e22BnVjcCPk/udK+0A9jRwGFEG8JD2si9ZXBmU4WsuqQEczuZn4ww=="],
+
+    "@react-email/code-inline": ["@react-email/code-inline@0.0.5", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA=="],
+
+    "@react-email/column": ["@react-email/column@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-Lqq17l7ShzJG/d3b1w/+lVO+gp2FM05ZUo/nW0rjxB8xBICXOVv6PqjDnn3FXKssvhO5qAV20lHM6S+spRhEwQ=="],
+
+    "@react-email/components": ["@react-email/components@0.5.6", "", { "dependencies": { "@react-email/body": "0.1.0", "@react-email/button": "0.2.0", "@react-email/code-block": "0.1.0", "@react-email/code-inline": "0.0.5", "@react-email/column": "0.0.13", "@react-email/container": "0.0.15", "@react-email/font": "0.0.9", "@react-email/head": "0.0.12", "@react-email/heading": "0.0.15", "@react-email/hr": "0.0.11", "@react-email/html": "0.0.11", "@react-email/img": "0.0.11", "@react-email/link": "0.0.12", "@react-email/markdown": "0.0.15", "@react-email/preview": "0.0.13", "@react-email/render": "1.3.2", "@react-email/row": "0.0.12", "@react-email/section": "0.0.16", "@react-email/tailwind": "1.2.2", "@react-email/text": "0.1.5" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-3o9ellDaF3bBcVMWeos9HI0iUIT1zGygPRcn9WSfI5JREORiN6ViEJIvz5SKWEn1KPNZtw/iaW8ct7PpVyhomg=="],
+
+    "@react-email/container": ["@react-email/container@0.0.15", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg=="],
+
+    "@react-email/font": ["@react-email/font@0.0.9", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-4zjq23oT9APXkerqeslPH3OZWuh5X4crHK6nx82mVHV2SrLba8+8dPEnWbaACWTNjOCbcLIzaC9unk7Wq2MIXw=="],
+
+    "@react-email/head": ["@react-email/head@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-X2Ii6dDFMF+D4niNwMAHbTkeCjlYYnMsd7edXOsi0JByxt9wNyZ9EnhFiBoQdqkE+SMDcu8TlNNttMrf5sJeMA=="],
+
+    "@react-email/heading": ["@react-email/heading@0.0.15", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg=="],
+
+    "@react-email/hr": ["@react-email/hr@0.0.11", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw=="],
+
+    "@react-email/html": ["@react-email/html@0.0.11", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qJhbOQy5VW5qzU74AimjAR9FRFQfrMa7dn4gkEXKMB/S9xZN8e1yC1uA9C15jkXI/PzmJ0muDIWmFwatm5/+VA=="],
+
+    "@react-email/img": ["@react-email/img@0.0.11", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ=="],
+
+    "@react-email/link": ["@react-email/link@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ=="],
+
+    "@react-email/markdown": ["@react-email/markdown@0.0.15", "", { "dependencies": { "md-to-react-email": "^5.0.5" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-UQA9pVm5sbflgtg3EX3FquUP4aMBzmLReLbGJ6DZQZnAskBF36aI56cRykDq1o+1jT+CKIK1CducPYziaXliag=="],
+
+    "@react-email/preview": ["@react-email/preview@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w=="],
+
     "@react-email/render": ["@react-email/render@1.3.1", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3", "react-promise-suspense": "^0.3.4" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-BOc/kanieEVyiuldFFvceriiBGBBVhe4JWWXCXE2ehLIqz+gSWD4rgCoXAGbJRnnVyyp4joPqK62bSfa88yonA=="],
+
+    "@react-email/row": ["@react-email/row@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-HkCdnEjvK3o+n0y0tZKXYhIXUNPDx+2vq1dJTmqappVHXS5tXS6W5JOPZr5j+eoZ8gY3PShI2LWj5rWF7ZEtIQ=="],
+
+    "@react-email/section": ["@react-email/section@0.0.16", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-FjqF9xQ8FoeUZYKSdt8sMIKvoT9XF8BrzhT3xiFKdEMwYNbsDflcjfErJe3jb7Wj/es/lKTbV5QR1dnLzGpL3w=="],
+
+    "@react-email/tailwind": ["@react-email/tailwind@1.2.2", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-heO9Khaqxm6Ulm6p7HQ9h01oiiLRrZuuEQuYds/O7Iyp3c58sMVHZGIxiRXO/kSs857NZQycpjewEVKF3jhNTw=="],
+
+    "@react-email/text": ["@react-email/text@0.1.5", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
@@ -1140,7 +1181,11 @@
 
     "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
 
+    "marked": ["marked@7.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "md-to-react-email": ["md-to-react-email@5.0.5", "", { "dependencies": { "marked": "7.0.4" }, "peerDependencies": { "react": "^18.0 || ^19.0" } }, "sha512-OvAXqwq57uOk+WZqFFNCMZz8yDp8BD3WazW1wAKHUrPbbdr89K9DWS6JXY09vd9xNdPNeurI8DU/X4flcfaD8A=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -1245,6 +1290,8 @@
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
     "prisma": ["prisma@6.16.3", "", { "dependencies": { "@prisma/config": "6.16.3", "@prisma/engines": "6.16.3" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-4tJq3KB9WRshH5+QmzOLV54YMkNlKOtLKaSdvraI5kC/axF47HuOw6zDM8xrxJ6s9o2WodY654On4XKkrobQdQ=="],
+
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -1513,6 +1560,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@prisma/config/c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
+
+    "@react-email/components/@react-email/render": ["@react-email/render@1.3.2", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3", "react-promise-suspense": "^0.3.4" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-oq8/BD/I/YspeuBjjdLJG6xaf9tsPYk+VWu8/mX9xWbRN0t0ExKSVm9sEBL6RsCpndQA2jbY2VgPEreIrzUgqw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-email/components": "^0.5.6",
     "@react-email/render": "^1.3.1",
     "@t3-oss/env-nextjs": "^0.13.8",
     "better-auth": "^1.3.25",

--- a/src/app/auth/email-verification/page.tsx
+++ b/src/app/auth/email-verification/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { MailIcon, RefreshCwIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import SignOutButton from "@/modules/auth/components/sign-out-button";
+import { authClient } from "@/modules/auth/lib/auth-client";
+
+export default function EmailVerificationPage() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { data: session } = authClient.useSession();
+
+  async function handleResendVerificationEmail() {
+    if (!session?.user?.email) {
+      toast.error("Email address not found. Please sign in again.");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const { error } = await authClient.sendVerificationEmail({
+        email: session.user.email,
+        callbackURL: "/dashboard",
+      });
+
+      if (error) {
+        toast.error(error.message || "Something went wrong");
+      } else {
+        toast.success("Verification email sent successfully");
+      }
+    } catch (error) {
+      console.error("Failed to send verification email:", error);
+      toast.error("Failed to send verification email");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <MailIcon className="w-12 h-12" />
+        </EmptyMedia>
+        <EmptyTitle>Check Your Email</EmptyTitle>
+        <EmptyDescription>
+          We&apos;ve sent a verification link to{" "}
+          {session?.user?.email ? (
+            <span className="font-bold">{session.user.email}</span>
+          ) : (
+            "your email address"
+          )}
+          . Please check your inbox and click the link to verify your account.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <div className="flex flex-col gap-3 w-full">
+          <Button
+            onClick={handleResendVerificationEmail}
+            disabled={isLoading}
+            className="w-full"
+          >
+            {isLoading ? (
+              <>
+                <RefreshCwIcon className="w-4 h-4 mr-2 animate-spin" />
+                Sending...
+              </>
+            ) : (
+              <>
+                <RefreshCwIcon className="w-4 h-4 mr-2" />
+                Resend Verification Email
+              </>
+            )}
+          </Button>
+
+          <SignOutButton variant="outline" className="w-full">
+            Sign Out (Wrong Email?)
+          </SignOutButton>
+        </div>
+      </EmptyContent>
+
+      <div className="text-center space-y-2">
+        <p className="text-sm text-muted-foreground">
+          Didn&apos;t receive the email?
+        </p>
+        <ul className="text-xs text-muted-foreground space-y-1">
+          <li>• Check your spam or junk folder</li>
+          <li>• Make sure the email address is correct</li>
+          <li>• Try resending the verification email</li>
+        </ul>
+      </div>
+
+      <div className="text-center">
+        <span className="text-sm text-muted-foreground">Need help? </span>
+        <a
+          href="#"
+          className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"
+        >
+          Contact Support
+        </a>
+      </div>
+    </Empty>
+  );
+}

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import { ForgotPasswordForm } from "@/modules/auth/components/forgot-password-form";
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />;
+}

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ResetPasswordForm } from "@/modules/auth/components/reset-password-form";
+import { AlertTriangleIcon } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+function ResetPasswordContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  if (!token) {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <AlertTriangleIcon className="w-12 h-12" />
+          </EmptyMedia>
+          <EmptyTitle>Invalid Reset Link</EmptyTitle>
+          <EmptyDescription>
+            The password reset link is invalid or has expired. Please request a
+            new one from the forgot password page.
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <div className="flex flex-col gap-3 w-full">
+            <Link href="/auth/forgot-password" className="w-full">
+              <Button className="w-full">Request New Reset Link</Button>
+            </Link>
+
+            <Link href="/auth/sign-in" className="w-full">
+              <Button variant="outline" className="w-full">
+                Back to Sign In
+              </Button>
+            </Link>
+          </div>
+        </EmptyContent>
+
+        <div className="text-center space-y-2">
+          <p className="text-sm text-muted-foreground">
+            Common issues with reset links:
+          </p>
+          <ul className="text-xs text-muted-foreground space-y-1">
+            <li>• The link has expired</li>
+            <li>• The link has already been used</li>
+          </ul>
+        </div>
+      </Empty>
+    );
+  }
+
+  return <ResetPasswordForm token={token} />;
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <AlertTriangleIcon className="w-12 h-12" />
+            </EmptyMedia>
+            <EmptyTitle>Loading...</EmptyTitle>
+            <EmptyDescription>
+              Please wait while we verify your reset link.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      }
+    >
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}

--- a/src/components/email-templates/email-verification.tsx
+++ b/src/components/email-templates/email-verification.tsx
@@ -9,50 +9,36 @@ import {
   Text,
 } from "@react-email/components";
 
-interface WelcomeEmailProps {
-  userName?: string;
-  dashboardUrl?: string;
+interface EmailVerificationEmailProps {
+  verificationUrl: string;
 }
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "";
 
-export const WelcomeEmail = ({
-  userName = "there",
-  dashboardUrl = `${baseUrl}/dashboard`,
-}: WelcomeEmailProps) => (
+export const EmailVerificationEmail = ({
+  verificationUrl,
+}: EmailVerificationEmailProps) => (
   <Html>
     <Head />
     <Body style={main}>
-      <Preview>Welcome to NextJS Starter Kit!</Preview>
+      <Preview>Verify your email address</Preview>
       <Container style={container}>
-        <Heading style={h1}>Welcome to NextJS Starter Kit!</Heading>
-        <Text style={text}>Hi {userName},</Text>
-        <Text style={text}>
-          Welcome to NextJS Starter Kit! We&apos;re excited to have you on
-          board. You&apos;ve successfully created your account and are now ready
-          to start building amazing web applications.
-        </Text>
-        <Text style={{ ...text, marginBottom: "14px" }}>
-          Here&apos;s what you can do next:
-        </Text>
-        <Text style={listItem}>
-          • Explore the pre-built components and UI elements
-        </Text>
-        <Text style={listItem}>• Set up your authentication preferences</Text>
-        <Text style={listItem}>• Customize your project settings</Text>
-        <Text style={listItem}>• Start building your first feature</Text>
+        <Heading style={h1}>Verify Your Email</Heading>
         <Link
-          href={dashboardUrl}
+          href={verificationUrl}
           target="_blank"
           style={{
             ...link,
             display: "block",
-            marginTop: "24px",
             marginBottom: "16px",
           }}
         >
-          Get started with your dashboard
+          Click here to verify your email address
         </Link>
+        <Text style={{ ...text, marginBottom: "14px" }}>
+          Or, copy and paste this verification URL:
+        </Text>
+        <Text style={url}>{verificationUrl}</Text>
         <Text
           style={{
             ...text,
@@ -61,8 +47,8 @@ export const WelcomeEmail = ({
             marginBottom: "16px",
           }}
         >
-          Need help getting started? Check out our documentation or reach out to
-          our support team.
+          If you didn&apos;t create an account, you can safely ignore this
+          email.
         </Text>
         <Text
           style={{
@@ -72,7 +58,7 @@ export const WelcomeEmail = ({
             marginBottom: "38px",
           }}
         >
-          Happy coding! We can&apos;t wait to see what you&apos;ll build.
+          Welcome to NextJS Starter Kit! Start building your next project.
         </Text>
         {/* <Img
           src={`${baseUrl}/logo.png`}
@@ -97,12 +83,11 @@ export const WelcomeEmail = ({
   </Html>
 );
 
-WelcomeEmail.PreviewProps = {
-  userName: "John Doe",
-  dashboardUrl: "https://example.com/dashboard",
-} as WelcomeEmailProps;
+EmailVerificationEmail.PreviewProps = {
+  verificationUrl: "https://example.com/verify?token=abc123",
+} as EmailVerificationEmailProps;
 
-export default WelcomeEmail;
+export default EmailVerificationEmail;
 
 const main = {
   backgroundColor: "#ffffff",
@@ -140,13 +125,16 @@ const text = {
   margin: "24px 0",
 };
 
-const listItem = {
+const url = {
+  display: "inline-block",
+  padding: "16px 4.5%",
+  width: "90.5%",
+  backgroundColor: "#f4f4f4",
+  borderRadius: "5px",
+  border: "1px solid #eee",
   color: "#333",
-  fontFamily:
-    "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
+  fontFamily: "monospace",
   fontSize: "14px",
-  margin: "8px 0",
-  paddingLeft: "16px",
 };
 
 const footer = {

--- a/src/components/email-templates/index.ts
+++ b/src/components/email-templates/index.ts
@@ -1,1 +1,3 @@
+export { EmailVerificationEmail } from "./email-verification";
+export { ResetPasswordEmail } from "./reset-password";
 export { WelcomeEmail } from "./welcome-email";

--- a/src/components/email-templates/reset-password.tsx
+++ b/src/components/email-templates/reset-password.tsx
@@ -9,50 +9,34 @@ import {
   Text,
 } from "@react-email/components";
 
-interface WelcomeEmailProps {
-  userName?: string;
-  dashboardUrl?: string;
+interface ResetPasswordEmailProps {
+  resetUrl: string;
 }
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "";
 
-export const WelcomeEmail = ({
-  userName = "there",
-  dashboardUrl = `${baseUrl}/dashboard`,
-}: WelcomeEmailProps) => (
+export const ResetPasswordEmail = ({ resetUrl }: ResetPasswordEmailProps) => (
   <Html>
     <Head />
     <Body style={main}>
-      <Preview>Welcome to NextJS Starter Kit!</Preview>
+      <Preview>Reset your password</Preview>
       <Container style={container}>
-        <Heading style={h1}>Welcome to NextJS Starter Kit!</Heading>
-        <Text style={text}>Hi {userName},</Text>
-        <Text style={text}>
-          Welcome to NextJS Starter Kit! We&apos;re excited to have you on
-          board. You&apos;ve successfully created your account and are now ready
-          to start building amazing web applications.
-        </Text>
-        <Text style={{ ...text, marginBottom: "14px" }}>
-          Here&apos;s what you can do next:
-        </Text>
-        <Text style={listItem}>
-          • Explore the pre-built components and UI elements
-        </Text>
-        <Text style={listItem}>• Set up your authentication preferences</Text>
-        <Text style={listItem}>• Customize your project settings</Text>
-        <Text style={listItem}>• Start building your first feature</Text>
+        <Heading style={h1}>Reset Your Password</Heading>
         <Link
-          href={dashboardUrl}
+          href={resetUrl}
           target="_blank"
           style={{
             ...link,
             display: "block",
-            marginTop: "24px",
             marginBottom: "16px",
           }}
         >
-          Get started with your dashboard
+          Click here to reset your password
         </Link>
+        <Text style={{ ...text, marginBottom: "14px" }}>
+          Or, copy and paste this reset URL:
+        </Text>
+        <Text style={url}>{resetUrl}</Text>
         <Text
           style={{
             ...text,
@@ -61,8 +45,8 @@ export const WelcomeEmail = ({
             marginBottom: "16px",
           }}
         >
-          Need help getting started? Check out our documentation or reach out to
-          our support team.
+          If you didn&apos;t request a password reset, you can safely ignore
+          this email.
         </Text>
         <Text
           style={{
@@ -72,7 +56,7 @@ export const WelcomeEmail = ({
             marginBottom: "38px",
           }}
         >
-          Happy coding! We can&apos;t wait to see what you&apos;ll build.
+          For security reasons, this link will expire in 24 hours.
         </Text>
         {/* <Img
           src={`${baseUrl}/logo.png`}
@@ -97,12 +81,11 @@ export const WelcomeEmail = ({
   </Html>
 );
 
-WelcomeEmail.PreviewProps = {
-  userName: "John Doe",
-  dashboardUrl: "https://example.com/dashboard",
-} as WelcomeEmailProps;
+ResetPasswordEmail.PreviewProps = {
+  resetUrl: "https://example.com/reset-password?token=abc123",
+} as ResetPasswordEmailProps;
 
-export default WelcomeEmail;
+export default ResetPasswordEmail;
 
 const main = {
   backgroundColor: "#ffffff",
@@ -140,13 +123,16 @@ const text = {
   margin: "24px 0",
 };
 
-const listItem = {
+const url = {
+  display: "inline-block",
+  padding: "16px 4.5%",
+  width: "90.5%",
+  backgroundColor: "#f4f4f4",
+  borderRadius: "5px",
+  border: "1px solid #eee",
   color: "#333",
-  fontFamily:
-    "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
+  fontFamily: "monospace",
   fontSize: "14px",
-  margin: "8px 0",
-  paddingLeft: "16px",
 };
 
 const footer = {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,3 +1,4 @@
+import { fromEmailSchema } from "@/schemas";
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
@@ -16,11 +17,13 @@ export const env = createEnv({
   },
   client: {
     NEXT_PUBLIC_BASE_URL: z.url(), // Public values safe for client
+    NEXT_PUBLIC_EMAIL_FROM: fromEmailSchema,
   },
   // Use experimental__runtimeEnv for client-side values that are only available at runtime,
   // e.g., dynamic URLs or keys that are not known at build time.
   // This is needed if your client env vars might change between builds and must be read from process.env at runtime.
   experimental__runtimeEnv: {
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
+    NEXT_PUBLIC_EMAIL_FROM: process.env.NEXT_PUBLIC_EMAIL_FROM,
   },
 });

--- a/src/modules/auth/components/forgot-password-form.tsx
+++ b/src/modules/auth/components/forgot-password-form.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { authClient } from "@/modules/auth/lib/auth-client";
+import { forgotPasswordSchema } from "@/modules/auth/schemas";
+import type { ForgotPasswordFormData } from "@/modules/auth/types";
+import { toast } from "sonner";
+
+interface ForgotPasswordFormProps {
+  onSuccess?: () => void;
+  redirectTo?: string;
+}
+
+export function ForgotPasswordForm({
+  onSuccess,
+  redirectTo = "/auth/reset-password",
+}: ForgotPasswordFormProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<ForgotPasswordFormData>({
+    resolver: zodResolver(forgotPasswordSchema),
+    mode: "onBlur",
+  });
+
+  const onSubmit = async (data: ForgotPasswordFormData) => {
+    setFormError(null);
+    setIsLoading(true);
+
+    try {
+      await authClient.requestPasswordReset(
+        {
+          email: data.email,
+          redirectTo: redirectTo,
+        },
+        {
+          onSuccess: () => {
+            setIsLoading(false);
+            toast.success(
+              "If account exists for this email, we've sent a password reset link."
+            );
+            reset();
+            router.push("/auth/sign-in");
+            onSuccess?.();
+          },
+          onError: (ctx) => {
+            setIsLoading(false);
+            setFormError(ctx.error.message || "Something went wrong");
+          },
+        }
+      );
+    } catch {
+      setIsLoading(false);
+      setFormError("An unexpected error occurred. Please try again.");
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto space-y-4">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">Forgot password</h1>
+        <p className="text-muted-foreground">
+          Enter your email address and we&apos;ll send you a link to reset your
+          password.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 mb-0">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="your@email.com"
+            {...register("email")}
+            aria-invalid={!!errors.email}
+            className={errors.email ? "border-destructive" : ""}
+          />
+          {errors.email && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.email.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {formError && (
+            <p className="text-sm text-destructive" role="alert">
+              {formError}
+            </p>
+          )}
+        </div>
+
+        <Button
+          type="submit"
+          className="w-full cursor-pointer"
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <>
+              <Spinner className="size-4" />
+              Sending reset link...
+            </>
+          ) : (
+            "Send reset link"
+          )}
+        </Button>
+      </form>
+
+      <div className="text-center mt-2 space-y-2">
+        <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
+          <span className="bg-background text-muted-foreground relative z-10 px-2">
+            Or
+          </span>
+        </div>
+        <Link href="/auth/sign-in" className="cursor-pointer">
+          <Button
+            variant="outline"
+            className="w-full cursor-pointer"
+            disabled={isLoading}
+          >
+            Sign in
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/auth/components/reset-password-form.tsx
+++ b/src/modules/auth/components/reset-password-form.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import { Label } from "@/components/ui/label";
+import { authClient } from "@/modules/auth/lib/auth-client";
+import { resetPasswordSchema } from "@/modules/auth/schemas";
+import type { ResetPasswordFormData } from "@/modules/auth/types";
+import { toast } from "sonner";
+import { PasswordInput } from "./password-input";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+interface ResetPasswordFormProps {
+  token: string;
+  onSuccess?: () => void;
+  redirectTo?: string;
+}
+
+export function ResetPasswordForm({
+  token,
+  onSuccess,
+  redirectTo = "/auth/sign-in",
+}: ResetPasswordFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(resetPasswordSchema),
+    mode: "onBlur",
+    defaultValues: { newPassword: "", newPasswordConfirmation: "" },
+  });
+
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    setFormError(null);
+    setIsLoading(true);
+
+    try {
+      await authClient.resetPassword(
+        {
+          token,
+          newPassword: data.newPassword,
+        },
+        {
+          onSuccess: () => {
+            setIsLoading(false);
+            toast.success("Password reset successfully");
+            reset();
+            router.push(redirectTo);
+            onSuccess?.();
+          },
+          onError: (ctx) => {
+            setIsLoading(false);
+            setFormError(ctx.error.message || "Something went wrong");
+          },
+        }
+      );
+    } catch {
+      setIsLoading(false);
+      setFormError("An unexpected error occurred. Please try again.");
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto space-y-4">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">Reset password</h1>
+        <p className="text-muted-foreground text-sm">
+          Enter your new password below.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 mb-0">
+        <div className="space-y-2">
+          <Label htmlFor="newPassword">Password</Label>
+          <PasswordInput
+            id="newPassword"
+            autoComplete="new-password"
+            placeholder="Password"
+            {...register("newPassword")}
+            aria-invalid={!!errors.newPassword}
+            className={errors.newPassword ? "border-destructive" : ""}
+          />
+          {errors.newPassword && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.newPassword.message}
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="newPasswordConfirmation">Confirm Password</Label>
+          <PasswordInput
+            id="newPasswordConfirmation"
+            autoComplete="new-password"
+            placeholder="Confirm password"
+            {...register("newPasswordConfirmation")}
+            aria-invalid={!!errors.newPasswordConfirmation}
+            className={
+              errors.newPasswordConfirmation ? "border-destructive" : ""
+            }
+          />
+          {errors.newPasswordConfirmation && (
+            <p className="text-sm text-destructive" role="alert">
+              {errors.newPasswordConfirmation.message}
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          {formError && (
+            <p className="text-sm text-destructive" role="alert">
+              {formError}
+            </p>
+          )}
+        </div>
+        <Button
+          type="submit"
+          className="w-full cursor-pointer"
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <>
+              <Spinner className="size-4" />
+              Resetting password...
+            </>
+          ) : (
+            "Reset password"
+          )}
+        </Button>
+      </form>
+
+      <div className="text-center mt-2 space-y-2">
+        <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
+          <span className="bg-background text-muted-foreground relative z-10 px-2">
+            Or
+          </span>
+        </div>
+        <Link href="/auth/sign-in" className="cursor-pointer">
+          <Button
+            variant="outline"
+            className="w-full cursor-pointer"
+            disabled={isLoading}
+          >
+            Sign in
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/auth/components/sign-out-button.tsx
+++ b/src/modules/auth/components/sign-out-button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { authClient } from "@/modules/auth/lib/auth-client";
+import { useRouter } from "next/navigation";
+import { useState, type ComponentProps } from "react";
+import { toast } from "sonner";
+
+type ButtonBaseProps = ComponentProps<typeof Button>;
+
+interface SignOutButtonProps extends ButtonBaseProps {
+  onSignedOut?: () => void;
+  children?: React.ReactNode;
+}
+
+export default function SignOutButton({
+  children = "Sign out",
+  onSignedOut,
+  ...props
+}: SignOutButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleSignOut() {
+    setLoading(true);
+
+    const { error } = await authClient.signOut();
+
+    setLoading(false);
+
+    if (error) {
+      toast.error(error.message || "Something went wrong");
+      return;
+    }
+
+    toast.success("Signed out successfully");
+    onSignedOut?.();
+    router.push("/auth/sign-in");
+  }
+
+  return (
+    <Button onClick={handleSignOut} disabled={loading} {...props}>
+      {loading ? (
+        <>
+          <Spinner className="size-4" />
+          Signing out...
+        </>
+      ) : (
+        children
+      )}
+    </Button>
+  );
+}

--- a/src/modules/auth/lib/auth.ts
+++ b/src/modules/auth/lib/auth.ts
@@ -1,7 +1,13 @@
-import { betterAuth } from "better-auth";
-import { prismaAdapter } from "better-auth/adapters/prisma";
+import {
+  EmailVerificationEmail,
+  ResetPasswordEmail,
+  WelcomeEmail,
+} from "@/components/email-templates";
+import { sendEmail } from "@/lib/email";
 import { env } from "@/lib/env";
 import prisma from "@/lib/prisma";
+import { betterAuth } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
 
 /**
  * Better Auth configuration for this Next.js app.
@@ -14,6 +20,36 @@ export const auth = betterAuth({
   }),
   emailAndPassword: {
     enabled: true,
+    async sendResetPassword({ user, url }) {
+      await sendEmail({
+        from: env.NEXT_PUBLIC_EMAIL_FROM,
+        to: user.email,
+        subject: "Reset your password",
+        react: ResetPasswordEmail({ resetUrl: url }),
+      });
+    },
+  },
+  emailVerification: {
+    sendOnSignUp: true,
+    autoSignInAfterVerification: true,
+    async sendVerificationEmail({ user, url }) {
+      await sendEmail({
+        from: env.NEXT_PUBLIC_EMAIL_FROM,
+        to: user.email,
+        subject: "Verify your email address",
+        react: EmailVerificationEmail({ verificationUrl: url }),
+      });
+    },
+    async afterEmailVerification(user) {
+      await sendEmail({
+        from: env.NEXT_PUBLIC_EMAIL_FROM,
+        to: user.email,
+        subject: "Welcome to NextJS Starter Kit!",
+        react: WelcomeEmail({
+          userName: user.name || user.email.split("@")[0],
+        }),
+      });
+    },
   },
 
   /**

--- a/src/modules/auth/schemas/forgot-password.ts
+++ b/src/modules/auth/schemas/forgot-password.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const forgotPasswordSchema = z.object({
+  email: z.email("Please enter a valid email address"),
+});

--- a/src/modules/auth/schemas/index.ts
+++ b/src/modules/auth/schemas/index.ts
@@ -1,2 +1,4 @@
+export { forgotPasswordSchema } from "./forgot-password";
+export { resetPasswordSchema } from "./reset-password";
 export { signInSchema } from "./sign-in";
 export { signUpSchema } from "./sign-up";

--- a/src/modules/auth/schemas/reset-password.ts
+++ b/src/modules/auth/schemas/reset-password.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const resetPasswordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(1, "Password is required")
+      .min(8, "Password must be at least 8 characters long")
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
+        "Password must contain at least one uppercase letter, one lowercase letter, and one number"
+      ),
+    newPasswordConfirmation: z
+      .string()
+      .min(1, { message: "Please confirm password" }),
+  })
+  .refine((data) => data.newPassword === data.newPasswordConfirmation, {
+    message: "Passwords do not match",
+    path: ["newPasswordConfirmation"],
+  });

--- a/src/modules/auth/types/forgot-password.ts
+++ b/src/modules/auth/types/forgot-password.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { forgotPasswordSchema } from "@/modules/auth/schemas";
+
+export type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;

--- a/src/modules/auth/types/index.ts
+++ b/src/modules/auth/types/index.ts
@@ -1,2 +1,4 @@
 export type { SignInFormData, SignInFormProps } from "./sign-in";
 export type { SignUpFormData, SignUpFormProps } from "./sign-up";
+export type { ForgotPasswordFormData } from "./forgot-password";
+export type { ResetPasswordFormData } from "./reset-password";

--- a/src/modules/auth/types/reset-password.ts
+++ b/src/modules/auth/types/reset-password.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { resetPasswordSchema } from "@/modules/auth/schemas";
+
+export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;

--- a/src/schemas/email.ts
+++ b/src/schemas/email.ts
@@ -7,7 +7,7 @@ const emailRecipientsSchema = z.union([
   z.array(emailStringSchema).min(1, "At least one recipient is required"),
 ]);
 
-const fromEmailSchema = z.string().refine(
+export const fromEmailSchema = z.string().refine(
   (val) => {
     const simpleEmailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (simpleEmailRegex.test(val)) {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,7 @@
-export { sendEmailOptionsSchema, sendEmailResponseSchema } from "./email";
+export {
+  fromEmailSchema,
+  sendEmailOptionsSchema,
+  sendEmailResponseSchema,
+} from "./email";
 
 export { formatValidationErrors, validateWithZod } from "./validation";


### PR DESCRIPTION
This commit introduces a complete email verification and password reset flow to enhance account security and user management.

- Implements email verification flow with a verification page and resend functionality.
- Implements password reset flow with forgot password and reset password pages.
- Adds `EmailVerificationEmail`, `ResetPasswordEmail`, and improved `WelcomeEmail` templates using `react-email`.
- Adds `ForgotPasswordForm`, `ResetPasswordForm`, and `SignOutButton` components.
- Updates `better-auth` configuration for the new authentication flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Forgot Password and Reset Password pages with validated forms, toasts, and navigation.
  - Introduced Email Verification page with resend option and sign-out.
  - Implemented email templates for Email Verification and Password Reset; revamped Welcome Email with improved design and preview.
  - Added reusable Sign Out button with loading state and feedback.

- Chores
  - Added @react-email/components dependency.
  - Exposed configurable sender email via environment variable (NEXT_PUBLIC_EMAIL_FROM).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->