### PR TITLE
feat(middleware): implement middleware for route protection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "nextjs-starter-kit",
       "dependencies": {
+        "@better-fetch/fetch": "^1.1.18",
         "@hookform/resolvers": "^5.2.2",
         "@prisma/client": "^6.16.3",
         "@prisma/extension-accelerate": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "auth:generate": "bunx @better-auth/cli generate --config ./src/modules/auth/lib/auth.ts"
   },
   "dependencies": {
+    "@better-fetch/fetch": "^1.1.18",
     "@hookform/resolvers": "^5.2.2",
     "@prisma/client": "^6.16.3",
     "@prisma/extension-accelerate": "^2.0.2",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,91 @@
+import { betterFetch } from "@better-fetch/fetch";
+import type { auth } from "@/modules/auth/lib/auth";
+import { type NextRequest, NextResponse } from "next/server";
+
+type Session = typeof auth.$Infer.Session;
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/_next/") ||
+    pathname.includes(".") ||
+    pathname === "/favicon.ico"
+  ) {
+    return NextResponse.next();
+  }
+
+  const publicRoutes = [
+    "/",
+    "/auth/sign-in",
+    "/auth/sign-up",
+    "/auth/forgot-password",
+    "/auth/reset-password",
+  ];
+
+  const isPublicRoute = publicRoutes.some((route) =>
+    pathname.startsWith(route)
+  );
+
+  try {
+    const { data: session } = await betterFetch<Session>(
+      "/api/auth/get-session",
+      {
+        baseURL: request.nextUrl.origin,
+        headers: {
+          cookie: request.headers.get("cookie") || "",
+        },
+      }
+    );
+
+    if (isPublicRoute && pathname.startsWith("/auth/") && session?.user) {
+      const callbackUrl = request.nextUrl.searchParams.get("callbackUrl");
+      const redirectUrl =
+        callbackUrl && callbackUrl.startsWith("/")
+          ? new URL(callbackUrl, request.url)
+          : new URL("/", request.url);
+      return NextResponse.redirect(redirectUrl);
+    }
+
+    if (!isPublicRoute && !session?.user) {
+      const signInUrl = new URL("/auth/sign-in", request.url);
+      signInUrl.searchParams.set("callbackUrl", pathname);
+      return NextResponse.redirect(signInUrl);
+    }
+
+    if (!isPublicRoute && session?.user && !session.user.emailVerified) {
+      const emailVerificationUrl = new URL(
+        "/auth/email-verification",
+        request.url
+      );
+      emailVerificationUrl.searchParams.set("callbackUrl", pathname);
+      return NextResponse.redirect(emailVerificationUrl);
+    }
+
+    return NextResponse.next();
+  } catch (error) {
+    console.error("Middleware auth error:", error);
+
+    if (!isPublicRoute) {
+      const signInUrl = new URL("/auth/sign-in", request.url);
+      signInUrl.searchParams.set("callbackUrl", pathname);
+      return NextResponse.redirect(signInUrl);
+    }
+
+    return NextResponse.next();
+  }
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+  ],
+};


### PR DESCRIPTION
This commit introduces a new middleware to handle route protection and authentication checks.

- Adds `@better-fetch/fetch` to fetch the user session on the server-side within the middleware.
- Creates a new middleware file `src/middleware.ts` that:
  - Protects routes based on user authentication status.
  - Redirects authenticated users from public auth pages (e.g., sign-in) to the dashboard.
  - Redirects unauthenticated users from protected routes to the sign-in page.
  - Redirects users to the email verification page if their email is not verified.
- Configures the matcher in the middleware to exclude API routes, static files, and images.